### PR TITLE
Update dependencies

### DIFF
--- a/Model/Import/CustomEntity.php
+++ b/Model/Import/CustomEntity.php
@@ -27,7 +27,7 @@ use Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\CollectionFactory;
 use Smile\CustomEntity\Api\CustomEntityRepositoryInterface;
 use Smile\CustomEntity\Api\Data\CustomEntityInterfaceFactory;
 use Magento\Framework\Api\SearchCriteriaBuilder;
-use Smile\ScopedEav\Model\Entity\FileInfo;
+use Magento\Catalog\Model\Category\FileInfo;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem;
 use Magento\ImportExport\Model\Import;

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     }
   ],
   "require": {
-    "php": "~7.1.3||~7.2.0",
-    "smile/module-custom-entity": "dev-master"
+    "php": "~7.1.3||~7.3.19",
+    "smile/module-custom-entity": "^1.1"
   },
   "license": "OSL-3.0",
   "authors": [


### PR DESCRIPTION
Fix dependencies to can install with composer

It is actually working with a Magento 2.3.5-p2 with php 7.3.18 and module "smile/module-custom-entity" in version 1.2.0 installed.
Just installed by copy paste in app/code/Smile